### PR TITLE
Allow the channel controller to be able to run outside of cluster

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,11 @@ GOHOSTARCH ?= $(shell go env GOHOSTARCH)
 KB_TOOLS_ARCHIVE_NAME :=kubebuilder-tools-$(K8S_VERSION)-$(GOHOSTOS)-$(GOHOSTARCH).tar.gz
 KB_TOOLS_ARCHIVE_PATH := $(TEST_TMP)/$(KB_TOOLS_ARCHIVE_NAME)
 
+.PHONY: local
+
+local:
+	@GOOS=darwin common/scripts/gobuild.sh build/_output/bin/multicluster-operators-channel ./cmd/manager
+
 .PHONY: build
 
 build:

--- a/cmd/manager/exec/manager.go
+++ b/cmd/manager/exec/manager.go
@@ -109,7 +109,7 @@ func RunManager() {
 	isExternalAPIServer := false
 	cfg = inConfig
 
-	if !equality.Semantic.DeepEqual(inConfig, outConfig) {
+	if outConfig != nil && !equality.Semantic.DeepEqual(inConfig, outConfig) {
 		cfg = outConfig
 		isExternalAPIServer = true
 	}

--- a/cmd/manager/exec/manager.go
+++ b/cmd/manager/exec/manager.go
@@ -15,9 +15,14 @@
 package exec
 
 import (
+	"errors"
 	"fmt"
+	"io/ioutil"
 	"log"
 	"os"
+
+	"k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/client-go/tools/clientcmd"
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/dynamic"
@@ -83,11 +88,34 @@ func RunManager() {
 
 	logger := logf.Log.WithName("set up manager")
 
-	// Get a config to talk to the apiserver
-	cfg, err := config.GetConfig()
+	var cfg, inConfig, outConfig *rest.Config
+
+	inConfig, err = config.GetConfig()
+
 	if err != nil {
 		logger.Error(err, "")
 		os.Exit(exitCode)
+	}
+
+	if options.KubeConfig != "" {
+		outConfig, err = getClientConfigFromKubeConfig(options.KubeConfig)
+	}
+
+	if err != nil {
+		logger.Error(err, "")
+		os.Exit(exitCode)
+	}
+
+	isExternalApiServer := false
+	cfg = inConfig
+
+	if !equality.Semantic.DeepEqual(inConfig, outConfig) {
+		cfg = outConfig
+		isExternalApiServer = true
+	}
+
+	if isExternalApiServer {
+		logger.Info("connect to external api server, kubeconfig:" + options.KubeConfig)
 	}
 
 	enableLeaderElection := false
@@ -97,11 +125,11 @@ func RunManager() {
 
 		enableLeaderElection = true
 	} else {
-		logger.Info("LeaderElection disabled as not running in a cluster")
+		logger.Info("LeaderElection disabled as not running in cluster")
 	}
 
 	// Create a new Cmd to provide shared dependencies and start components
-	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
+	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		MetricsBindAddress:      fmt.Sprintf("%s:%d", metricsHost, metricsPort),
 		Port:                    operatorMetricsPort,
 		LeaderElection:          enableLeaderElection,
@@ -115,7 +143,7 @@ func RunManager() {
 	}
 
 	// Create dynamic client
-	dynamicClient := dynamic.NewForConfigOrDie(ctrl.GetConfigOrDie())
+	dynamicClient := dynamic.NewForConfigOrDie(cfg)
 
 	// Create channel descriptor is user for the object bucket
 	chdesc, err := utils.CreateObjectStorageChannelDescriptor()
@@ -169,9 +197,15 @@ func RunManager() {
 			os.Exit(exitCode)
 		}
 
-		clt, err := client.New(ctrl.GetConfigOrDie(), client.Options{})
+		clt, err := client.New(cfg, client.Options{})
 		if err != nil {
 			logger.Error(err, "failed to create a client for webhook to get CA cert secret")
+			os.Exit(exitCode)
+		}
+
+		inClt, err := client.New(inConfig, client.Options{})
+		if err != nil {
+			logger.Error(err, "failed to create the in-cluster client")
 			os.Exit(exitCode)
 		}
 
@@ -182,7 +216,8 @@ func RunManager() {
 		}
 
 		go func() {
-			if err := wiredWebhook.WireUpWebhookSupplymentryResource(caCert, chv1.SchemeGroupVersion.WithKind(kindName),
+			if err := wiredWebhook.WireUpWebhookSupplymentryResource(isExternalApiServer, inClt,
+				caCert, chv1.SchemeGroupVersion.WithKind(kindName),
 				[]admissionv1.OperationType{admissionv1.Create}, chWebhook.DelPreValiationCfg20); err != nil {
 				logger.Error(err, "failed to set up webhook configuration")
 				os.Exit(exitCode)
@@ -196,4 +231,31 @@ func RunManager() {
 		logger.Error(err, "Manager exited non-zero")
 		os.Exit(exitCode)
 	}
+}
+
+func getClientConfigFromKubeConfig(kubeconfigFile string) (*rest.Config, error) {
+	if len(kubeconfigFile) > 0 {
+		return GetClientConfig(kubeconfigFile)
+	}
+
+	return nil, errors.New("no kubeconfig file found")
+}
+
+func GetClientConfig(kubeConfigFile string) (*rest.Config, error) {
+	kubeConfigBytes, err := ioutil.ReadFile(kubeConfigFile)
+	if err != nil {
+		return nil, err
+	}
+
+	kubeConfig, err := clientcmd.NewClientConfigFromBytes(kubeConfigBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	clientConfig, err := kubeConfig.ClientConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	return clientConfig, nil
 }

--- a/cmd/manager/exec/manager.go
+++ b/cmd/manager/exec/manager.go
@@ -106,15 +106,15 @@ func RunManager() {
 		os.Exit(exitCode)
 	}
 
-	isExternalApiServer := false
+	isExternalAPIServer := false
 	cfg = inConfig
 
 	if !equality.Semantic.DeepEqual(inConfig, outConfig) {
 		cfg = outConfig
-		isExternalApiServer = true
+		isExternalAPIServer = true
 	}
 
-	if isExternalApiServer {
+	if isExternalAPIServer {
 		logger.Info("connect to external api server, kubeconfig:" + options.KubeConfig)
 	}
 
@@ -216,7 +216,7 @@ func RunManager() {
 		}
 
 		go func() {
-			if err := wiredWebhook.WireUpWebhookSupplymentryResource(isExternalApiServer, inClt,
+			if err := wiredWebhook.WireUpWebhookSupplymentryResource(isExternalAPIServer, inClt,
 				caCert, chv1.SchemeGroupVersion.WithKind(kindName),
 				[]admissionv1.OperationType{admissionv1.Create}, chWebhook.DelPreValiationCfg20); err != nil {
 				logger.Error(err, "failed to set up webhook configuration")

--- a/cmd/manager/exec/options.go
+++ b/cmd/manager/exec/options.go
@@ -22,6 +22,7 @@ const defaultSyncInterval = 60 //seconds
 // ChannelCMDOptions for command line flag parsing
 type ChannelCMDOptions struct {
 	MetricsAddr  string
+	KubeConfig   string
 	SyncInterval int
 	LeaderElect  bool
 	Debug        bool
@@ -71,6 +72,13 @@ func ProcessFlags() {
 		"The address the metric endpoint binds to.",
 	)
 
+	flag.StringVar(
+		&options.KubeConfig,
+		"kubeconfig",
+		options.KubeConfig,
+		"The kube config that points to an external api server.",
+	)
+
 	flag.IntVar(
 		&options.SyncInterval,
 		"sync-interval",
@@ -82,7 +90,7 @@ func ProcessFlags() {
 		&options.Debug,
 		"debug",
 		false,
-		"if debug is true, then webhooks will be created",
+		"if debug is true, then local webhooks will not be created",
 	)
 
 	flag.BoolVar(

--- a/pkg/webhook/wireupwebhook.go
+++ b/pkg/webhook/wireupwebhook.go
@@ -151,7 +151,7 @@ func DelPreValiationCfg20(clt client.Client) error {
 
 //assuming we have a service set up for the webhook, and the service is linking
 //to a secret which has the CA
-func (w *WireUp) WireUpWebhookSupplymentryResource(isExternalApiServer bool, inClient client.Client,
+func (w *WireUp) WireUpWebhookSupplymentryResource(isExternalAPIServer bool, inClient client.Client,
 	caCert []byte, gvk schema.GroupVersionKind, ops []admissionv1.OperationType, cFuncs ...CleanUpFunc) error {
 	w.Logger.Info("entry wire up webhook resources")
 	defer w.Logger.Info("exit wire up webhook resources")
@@ -168,7 +168,7 @@ func (w *WireUp) WireUpWebhookSupplymentryResource(isExternalApiServer bool, inC
 		}
 	}
 
-	return gerr.Wrap(w.createOrUpdateValiationWebhook(isExternalApiServer, inClient, caCert, gvk, ops), "failed to set up the validation webhook config")
+	return gerr.Wrap(w.createOrUpdateValiationWebhook(isExternalAPIServer, inClient, caCert, gvk, ops), "failed to set up the validation webhook config")
 }
 
 func findEnvVariable(envName string) (string, error) {
@@ -180,7 +180,7 @@ func findEnvVariable(envName string) (string, error) {
 	return val, nil
 }
 
-func (w *WireUp) getOrCreateWebhookService(isExternalApiServer bool, inClusterClient client.Client) error {
+func (w *WireUp) getOrCreateWebhookService(isExternalAPIServer bool, inClusterClient client.Client) error {
 	service := &corev1.Service{}
 
 	outCLusterClient := w.mgr.GetClient()
@@ -215,8 +215,8 @@ func (w *WireUp) getOrCreateWebhookService(isExternalApiServer bool, inClusterCl
 
 	w.Logger.Info(fmt.Sprintf("created in Cluster service %s ", w.WebHookeSvcKey.String()))
 
-	// 2. If isExternalApiServer = true, create the additional service in the hosted cluster
-	if !isExternalApiServer {
+	// 2. If isExternalAPIServer = true, create the additional service in the hosted cluster
+	if !isExternalAPIServer {
 		return nil
 	}
 
@@ -259,7 +259,7 @@ func (w *WireUp) getOrCreateWebhookService(isExternalApiServer bool, inClusterCl
 		return errors.New("no service Cluster IP found: " + w.WebHookeSvcKey.String())
 	}
 
-	// 4. If isExternalApiServer = true, create the additional endpoint in the hosted cluster
+	// 4. If isExternalAPIServer = true, create the additional endpoint in the hosted cluster
 	endpoint := &corev1.Endpoints{}
 	err = outCLusterClient.Get(context.TODO(), w.WebHookeSvcKey, endpoint)
 
@@ -288,7 +288,7 @@ func (w *WireUp) getOrCreateWebhookService(isExternalApiServer bool, inClusterCl
 	return nil
 }
 
-func (w *WireUp) createOrUpdateValiationWebhook(isExternalApiServer bool, inClient client.Client,
+func (w *WireUp) createOrUpdateValiationWebhook(isExternalAPIServer bool, inClient client.Client,
 	ca []byte, gvk schema.GroupVersionKind,
 	ops []admissionv1.OperationType) error {
 	validator := &admissionv1.ValidatingWebhookConfiguration{}
@@ -323,7 +323,7 @@ func (w *WireUp) createOrUpdateValiationWebhook(isExternalApiServer bool, inClie
 	}
 
 	// make sure the service of the validator exists
-	return gerr.Wrap(w.getOrCreateWebhookService(isExternalApiServer, inClient), "failed to set up service for webhook")
+	return gerr.Wrap(w.getOrCreateWebhookService(isExternalAPIServer, inClient), "failed to set up service for webhook")
 }
 
 func setOwnerReferences(c client.Client, logger logr.Logger, deployNs string, deployLabel string, obj metav1.Object) {
@@ -367,9 +367,9 @@ func setWebhookOwnerReferences(c client.Client, logger logr.Logger, obj metav1.O
 	})
 }
 
-func newWebhookServiceTemplate(isExternalApiServer bool, svcKey types.NamespacedName, webHookPort,
+func newWebhookServiceTemplate(isExternalAPIServer bool, svcKey types.NamespacedName, webHookPort,
 	webHookServicePort int, deploymentSelector map[string]string) *corev1.Service {
-	if isExternalApiServer {
+	if isExternalAPIServer {
 		// if the service is created on hosted cluster, no selector and target port should be specicified as the webhook server pod is not running there
 		return &corev1.Service{
 			TypeMeta: metav1.TypeMeta{

--- a/pkg/webhook/wireupwebhook.go
+++ b/pkg/webhook/wireupwebhook.go
@@ -16,6 +16,7 @@ package webhook
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -31,7 +32,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 
 	admissionv1 "k8s.io/api/admissionregistration/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 
 	"github.com/go-logr/logr"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -138,7 +139,7 @@ func DelPreValiationCfg20(clt client.Client) error {
 	ctx := context.TODO()
 
 	if err := clt.Get(ctx, pCfgKey, pCfg); err != nil {
-		if errors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			return nil
 		}
 
@@ -150,7 +151,8 @@ func DelPreValiationCfg20(clt client.Client) error {
 
 //assuming we have a service set up for the webhook, and the service is linking
 //to a secret which has the CA
-func (w *WireUp) WireUpWebhookSupplymentryResource(caCert []byte, gvk schema.GroupVersionKind, ops []admissionv1.OperationType, cFuncs ...CleanUpFunc) error {
+func (w *WireUp) WireUpWebhookSupplymentryResource(isExternalApiServer bool, inClient client.Client,
+	caCert []byte, gvk schema.GroupVersionKind, ops []admissionv1.OperationType, cFuncs ...CleanUpFunc) error {
 	w.Logger.Info("entry wire up webhook resources")
 	defer w.Logger.Info("exit wire up webhook resources")
 
@@ -166,7 +168,7 @@ func (w *WireUp) WireUpWebhookSupplymentryResource(caCert []byte, gvk schema.Gro
 		}
 	}
 
-	return gerr.Wrap(w.createOrUpdateValiationWebhook(caCert, gvk, ops), "failed to set up the validation webhook config")
+	return gerr.Wrap(w.createOrUpdateValiationWebhook(isExternalApiServer, inClient, caCert, gvk, ops), "failed to set up the validation webhook config")
 }
 
 func findEnvVariable(envName string) (string, error) {
@@ -178,39 +180,116 @@ func findEnvVariable(envName string) (string, error) {
 	return val, nil
 }
 
-func (w *WireUp) getOrCreateWebhookService() error {
+func (w *WireUp) getOrCreateWebhookService(isExternalApiServer bool, inClusterClient client.Client) error {
 	service := &corev1.Service{}
 
-	err := w.mgr.GetClient().Get(context.TODO(), w.WebHookeSvcKey, service)
+	outCLusterClient := w.mgr.GetClient()
+
+	// 1. On the management cluster, create the service for exposing the channel webhook server (channel pod)
+	err := inClusterClient.Get(context.TODO(), w.WebHookeSvcKey, service)
 
 	if err == nil {
 		// This channel container could be running in a different pod. Delete and re-create the service
 		// to ensure that the service always points to the correct target pod.
-		deleteErr := w.mgr.GetClient().Delete(context.TODO(), service)
+		deleteErr := inClusterClient.Delete(context.TODO(), service)
 
 		if deleteErr != nil {
 			w.Logger.Error(gerr.New(fmt.Sprintf("failed to delete existing service %s", w.WebHookeSvcKey.String())),
 				fmt.Sprintf("failed to delete existing service %s", w.WebHookeSvcKey.String()))
+
 			return deleteErr
 		}
 
 		w.Logger.Info(fmt.Sprintf("deleted existing service %s", w.WebHookeSvcKey.String()))
 	}
 
-	newService := newWebhookServiceTemplate(w.WebHookeSvcKey, w.WebHookPort, w.WebHookServicePort, w.DeploymentSelector)
+	w.Logger.Info(fmt.Sprintf("creating in Cluster service %s ", w.WebHookeSvcKey.String()))
 
-	setOwnerReferences(w.mgr.GetClient(), w.Logger, w.WebHookeSvcKey.Namespace, w.DeployLabel, newService)
+	newService := newWebhookServiceTemplate(false, w.WebHookeSvcKey, w.WebHookPort, w.WebHookServicePort, w.DeploymentSelector)
 
-	if err := w.mgr.GetClient().Create(context.TODO(), newService); err != nil {
+	setOwnerReferences(inClusterClient, w.Logger, w.WebHookeSvcKey.Namespace, w.DeployLabel, newService)
+
+	if err := inClusterClient.Create(context.TODO(), newService); err != nil {
 		return err
 	}
 
-	w.Logger.Info(fmt.Sprintf("created service %s ", w.WebHookeSvcKey.String()))
+	w.Logger.Info(fmt.Sprintf("created in Cluster service %s ", w.WebHookeSvcKey.String()))
+
+	// 2. If isExternalApiServer = true, create the additional service in the hosted cluster
+	if !isExternalApiServer {
+		return nil
+	}
+
+	service = &corev1.Service{}
+	err = outCLusterClient.Get(context.TODO(), w.WebHookeSvcKey, service)
+
+	if err == nil {
+		// Delete and re-create the service to ensure that the service always points to the correct target pod.
+		deleteErr := outCLusterClient.Delete(context.TODO(), service)
+
+		if deleteErr != nil {
+			w.Logger.Error(gerr.New(fmt.Sprintf("failed to delete existing service %s on hosted cluster", w.WebHookeSvcKey.String())),
+				fmt.Sprintf("failed to delete existing service %s on hosted cluster", w.WebHookeSvcKey.String()))
+
+			return deleteErr
+		}
+
+		w.Logger.Info(fmt.Sprintf("deleted existing service %s on hosted cluster", w.WebHookeSvcKey.String()))
+	}
+
+	newService = newWebhookServiceTemplate(true, w.WebHookeSvcKey, w.WebHookPort, w.WebHookServicePort, w.DeploymentSelector)
+
+	if err := outCLusterClient.Create(context.TODO(), newService); err != nil {
+		return err
+	}
+
+	w.Logger.Info(fmt.Sprintf("created hosted cluster service %s ", w.WebHookeSvcKey.String()))
+
+	// 3. get the service Cluster IP of the webhook server running on the management cluster. The service is created in step 1
+
+	service = &corev1.Service{}
+
+	if err = inClusterClient.Get(context.TODO(), w.WebHookeSvcKey, service); err != nil {
+		return err
+	}
+
+	serviceClusterIP := service.Spec.ClusterIP
+
+	if serviceClusterIP == "" {
+		return errors.New("no service Cluster IP found: " + w.WebHookeSvcKey.String())
+	}
+
+	// 4. If isExternalApiServer = true, create the additional endpoint in the hosted cluster
+	endpoint := &corev1.Endpoints{}
+	err = outCLusterClient.Get(context.TODO(), w.WebHookeSvcKey, endpoint)
+
+	if err == nil {
+		// Delete and re-create the endpoint to ensure that the service always points to the correct endpoint
+		deleteErr := outCLusterClient.Delete(context.TODO(), endpoint)
+
+		if deleteErr != nil {
+			w.Logger.Error(gerr.New(fmt.Sprintf("failed to delete existing endpoint %s on hosted cluster", w.WebHookeSvcKey.String())),
+				fmt.Sprintf("failed to delete existing endpoint %s on hosted cluster", w.WebHookeSvcKey.String()))
+
+			return deleteErr
+		}
+
+		w.Logger.Info(fmt.Sprintf("deleted existing endpoint %s on hosted cluster", w.WebHookeSvcKey.String()))
+	}
+
+	newEndpoint := newWebhookEndpointTemplate(w.WebHookeSvcKey, w.WebHookServicePort, serviceClusterIP)
+
+	if err := outCLusterClient.Create(context.TODO(), newEndpoint); err != nil {
+		return err
+	}
+
+	w.Logger.Info(fmt.Sprintf("created hosted cluster endpoint %s ", w.WebHookeSvcKey.String()))
 
 	return nil
 }
 
-func (w *WireUp) createOrUpdateValiationWebhook(ca []byte, gvk schema.GroupVersionKind,
+func (w *WireUp) createOrUpdateValiationWebhook(isExternalApiServer bool, inClient client.Client,
+	ca []byte, gvk schema.GroupVersionKind,
 	ops []admissionv1.OperationType) error {
 	validator := &admissionv1.ValidatingWebhookConfiguration{}
 	key := types.NamespacedName{Name: GetValidatorName(w.WebhookName)}
@@ -218,7 +297,7 @@ func (w *WireUp) createOrUpdateValiationWebhook(ca []byte, gvk schema.GroupVersi
 	validatorName := GetValidatorName(w.WebhookName)
 
 	if err := w.mgr.GetClient().Get(context.TODO(), key, validator); err != nil {
-		if errors.IsNotFound(err) { // create a new validator
+		if apierrors.IsNotFound(err) { // create a new validator
 			cfg := newValidatingWebhookCfg(w.WebHookeSvcKey, validatorName, w.ValidtorPath, ca, gvk, ops)
 
 			setWebhookOwnerReferences(w.mgr.GetClient(), w.Logger, cfg)
@@ -244,7 +323,7 @@ func (w *WireUp) createOrUpdateValiationWebhook(ca []byte, gvk schema.GroupVersi
 	}
 
 	// make sure the service of the validator exists
-	return gerr.Wrap(w.getOrCreateWebhookService(), "failed to set up service for webhook")
+	return gerr.Wrap(w.getOrCreateWebhookService(isExternalApiServer, inClient), "failed to set up service for webhook")
 }
 
 func setOwnerReferences(c client.Client, logger logr.Logger, deployNs string, deployLabel string, obj metav1.Object) {
@@ -256,8 +335,16 @@ func setOwnerReferences(c client.Client, logger logr.Logger, deployNs string, de
 		return
 	}
 
+	logger.Info(fmt.Sprintf("apiversion: %v, kind: %v, name: %v, uid: %v", owner.APIVersion, owner.Kind, owner.Name, owner.UID))
+
 	obj.SetOwnerReferences([]metav1.OwnerReference{
-		*metav1.NewControllerRef(owner, owner.GetObjectKind().GroupVersionKind())})
+		{
+			APIVersion: "apps/v1",
+			Kind:       "Deployment",
+			Name:       owner.Name,
+			UID:        owner.UID,
+		},
+	})
 }
 
 func setWebhookOwnerReferences(c client.Client, logger logr.Logger, obj metav1.Object) {
@@ -280,8 +367,34 @@ func setWebhookOwnerReferences(c client.Client, logger logr.Logger, obj metav1.O
 	})
 }
 
-func newWebhookServiceTemplate(svcKey types.NamespacedName, webHookPort, webHookServicePort int, deploymentSelector map[string]string) *corev1.Service {
+func newWebhookServiceTemplate(isExternalApiServer bool, svcKey types.NamespacedName, webHookPort,
+	webHookServicePort int, deploymentSelector map[string]string) *corev1.Service {
+	if isExternalApiServer {
+		// if the service is created on hosted cluster, no selector and target port should be specicified as the webhook server pod is not running there
+		return &corev1.Service{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "Service",
+				APIVersion: "v1",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      svcKey.Name,
+				Namespace: svcKey.Namespace,
+			},
+			Spec: corev1.ServiceSpec{
+				Ports: []corev1.ServicePort{
+					{
+						Port: int32(webHookServicePort),
+					},
+				},
+			},
+		}
+	}
+
 	return &corev1.Service{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Service",
+			APIVersion: "v1",
+		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      svcKey.Name,
 			Namespace: svcKey.Namespace,
@@ -294,6 +407,33 @@ func newWebhookServiceTemplate(svcKey types.NamespacedName, webHookPort, webHook
 				},
 			},
 			Selector: deploymentSelector,
+		},
+	}
+}
+
+func newWebhookEndpointTemplate(svcKey types.NamespacedName, webHookServicePort int, serviceClusterIP string) *corev1.Endpoints {
+	return &corev1.Endpoints{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Endpoints",
+			APIVersion: "v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      svcKey.Name,
+			Namespace: svcKey.Namespace,
+		},
+		Subsets: []corev1.EndpointSubset{
+			{
+				Addresses: []corev1.EndpointAddress{
+					{
+						IP: serviceClusterIP,
+					},
+				},
+				Ports: []corev1.EndpointPort{
+					{
+						Port: int32(webHookServicePort),
+					},
+				},
+			},
 		},
 	}
 }

--- a/pkg/webhook/wireupwebhook_test.go
+++ b/pkg/webhook/wireupwebhook_test.go
@@ -71,7 +71,7 @@ var _ = PDescribe("test if webhook's supplymentryResource create properly", func
 			caCert, err := wireUp.Attach(clt)
 			Expect(err).NotTo(HaveOccurred())
 
-			wireUp.WireUpWebhookSupplymentryResource(caCert,
+			wireUp.WireUpWebhookSupplymentryResource(false, clt, caCert,
 				schema.GroupVersionKind{Group: "", Version: "v1", Kind: "channels"},
 				[]admissionv1.OperationType{admissionv1.Create})
 


### PR DESCRIPTION
Signed-off-by: Xiangjing Li <xiangli@redhat.com>

1.  The channel controller is supported to specify an external kubeconfig argument, so that the channel controller running on a management cluster can reconcile resources deployed on the hosted clusters.

2.  Two clients (inCluster Client and outCluster Client) are maintained, so that the channel controller is able to update the webhook configuration service in the hosted cluster by outClient client and update the webhook server service in the management cluster by inCluster client

3.  If the kubeconfig argument is not specified, the channel controller is to use inCluster client by default. This is to align with the current ACM installation.