### PR TITLE
Add default controller leader election setting values

### DIFF
--- a/cmd/manager/exec/manager.go
+++ b/cmd/manager/exec/manager.go
@@ -21,6 +21,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"time"
 
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/client-go/tools/clientcmd"
@@ -130,6 +131,9 @@ func RunManager() {
 		logger.Info("LeaderElection disabled as not running in cluster")
 	}
 
+	leaseDuration := time.Duration(options.LeaseDurationSeconds) * time.Second
+	renewDeadline := time.Duration(options.RenewDeadlineSeconds) * time.Second
+	retryPeriod := time.Duration(options.RetryPeriodSeconds) * time.Second
 	// Create a new Cmd to provide shared dependencies and start components
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		MetricsBindAddress:      fmt.Sprintf("%s:%d", metricsHost, metricsPort),
@@ -137,6 +141,9 @@ func RunManager() {
 		LeaderElection:          enableLeaderElection,
 		LeaderElectionID:        "multicloud-operators-channel-leader.open-cluster-management.io",
 		LeaderElectionNamespace: "kube-system",
+		LeaseDuration:           &leaseDuration,
+		RenewDeadline:           &renewDeadline,
+		RetryPeriod:             &retryPeriod,
 	})
 
 	if err != nil {

--- a/cmd/manager/exec/options.go
+++ b/cmd/manager/exec/options.go
@@ -21,20 +21,26 @@ const defaultSyncInterval = 60 //seconds
 
 // ChannelCMDOptions for command line flag parsing
 type ChannelCMDOptions struct {
-	MetricsAddr  string
-	KubeConfig   string
-	SyncInterval int
-	LeaderElect  bool
-	Debug        bool
-	LogLevel     bool
+	MetricsAddr          string
+	KubeConfig           string
+	SyncInterval         int
+	LeaderElect          bool
+	Debug                bool
+	LogLevel             bool
+	LeaseDurationSeconds int
+	RenewDeadlineSeconds int
+	RetryPeriodSeconds   int
 }
 
 var (
 	options = ChannelCMDOptions{
-		MetricsAddr:  "",
-		SyncInterval: defaultSyncInterval,
-		Debug:        false,
-		LogLevel:     false,
+		MetricsAddr:          "",
+		SyncInterval:         defaultSyncInterval,
+		Debug:                false,
+		LogLevel:             false,
+		LeaseDurationSeconds: 137,
+		RenewDeadlineSeconds: 107,
+		RetryPeriodSeconds:   26,
 	}
 )
 
@@ -98,5 +104,26 @@ func ProcessFlags() {
 		"zap-devel",
 		false,
 		"zap-devel, default only log INFO(fasle), set to true for debugging",
+	)
+
+	flag.IntVar(
+		&options.LeaseDurationSeconds,
+		"lease-duration",
+		options.LeaseDurationSeconds,
+		"The lease duration in seconds.",
+	)
+
+	flag.IntVar(
+		&options.RenewDeadlineSeconds,
+		"renew-deadline",
+		options.RenewDeadlineSeconds,
+		"The renew deadline in seconds.",
+	)
+
+	flag.IntVar(
+		&options.RetryPeriodSeconds,
+		"retry-period",
+		options.RetryPeriodSeconds,
+		"The retry period in seconds.",
 	)
 }


### PR DESCRIPTION
Following recommended default settings of leaseDuration=137s, renewDeadline=107s, and retryPeriod=26s from https://github.com/openshift/library-go/blob/4b9033d00d37b88393f837a88ff541a56fd13621/pkg/config/leaderelection/leaderelection.go#L84


https://github.com/stolostron/backlog/issues/25245
Signed-off-by: Jonathan Marcantonio <jmarcant@redhat.com>