### PR TITLE
Change lease-duration to leader-election-lease-duration

### DIFF
--- a/cmd/manager/exec/manager.go
+++ b/cmd/manager/exec/manager.go
@@ -131,7 +131,7 @@ func RunManager() {
 		logger.Info("LeaderElection disabled as not running in cluster")
 	}
 
-	leaseDuration := time.Duration(options.LeaseDurationSeconds) * time.Second
+	leaseDuration := time.Duration(options.LeaderElectionLeaseDurationSeconds) * time.Second
 	renewDeadline := time.Duration(options.RenewDeadlineSeconds) * time.Second
 	retryPeriod := time.Duration(options.RetryPeriodSeconds) * time.Second
 	// Create a new Cmd to provide shared dependencies and start components

--- a/cmd/manager/exec/options.go
+++ b/cmd/manager/exec/options.go
@@ -21,26 +21,26 @@ const defaultSyncInterval = 60 //seconds
 
 // ChannelCMDOptions for command line flag parsing
 type ChannelCMDOptions struct {
-	MetricsAddr          string
-	KubeConfig           string
-	SyncInterval         int
-	LeaderElect          bool
-	Debug                bool
-	LogLevel             bool
-	LeaseDurationSeconds int
-	RenewDeadlineSeconds int
-	RetryPeriodSeconds   int
+	MetricsAddr                        string
+	KubeConfig                         string
+	SyncInterval                       int
+	LeaderElect                        bool
+	Debug                              bool
+	LogLevel                           bool
+	LeaderElectionLeaseDurationSeconds int
+	RenewDeadlineSeconds               int
+	RetryPeriodSeconds                 int
 }
 
 var (
 	options = ChannelCMDOptions{
-		MetricsAddr:          "",
-		SyncInterval:         defaultSyncInterval,
-		Debug:                false,
-		LogLevel:             false,
-		LeaseDurationSeconds: 137,
-		RenewDeadlineSeconds: 107,
-		RetryPeriodSeconds:   26,
+		MetricsAddr:                        "",
+		SyncInterval:                       defaultSyncInterval,
+		Debug:                              false,
+		LogLevel:                           false,
+		LeaderElectionLeaseDurationSeconds: 137,
+		RenewDeadlineSeconds:               107,
+		RetryPeriodSeconds:                 26,
 	}
 )
 
@@ -107,10 +107,10 @@ func ProcessFlags() {
 	)
 
 	flag.IntVar(
-		&options.LeaseDurationSeconds,
-		"lease-duration",
-		options.LeaseDurationSeconds,
-		"The lease duration in seconds.",
+		&options.LeaderElectionLeaseDurationSeconds,
+		"leader-election-lease-duration",
+		options.LeaderElectionLeaseDurationSeconds,
+		"The leader election lease duration in seconds.",
 	)
 
 	flag.IntVar(


### PR DESCRIPTION
Signed-off-by: Jonathan Marcantonio <jmarcant@redhat.com>

While writing the [doc issue](https://github.com/stolostron/backlog/issues/25868) for https://github.com/stolostron/backlog/issues/25245 I noticed inconsistent naming of the lease duration flag. This change will keep the flag consistent for all the different parts of the controllers.