### PR TITLE
Enforce server side TLSv1.2

### DIFF
--- a/cmd/manager/exec/manager.go
+++ b/cmd/manager/exec/manager.go
@@ -52,6 +52,7 @@ import (
 	"open-cluster-management.io/multicloud-operators-channel/pkg/controller"
 	"open-cluster-management.io/multicloud-operators-channel/pkg/utils"
 	chWebhook "open-cluster-management.io/multicloud-operators-channel/pkg/webhook"
+	k8swebhook "sigs.k8s.io/controller-runtime/pkg/webhook"
 )
 
 // Change below variables to serve metrics on different host or port.
@@ -144,6 +145,7 @@ func RunManager() {
 		LeaseDuration:           &leaseDuration,
 		RenewDeadline:           &renewDeadline,
 		RetryPeriod:             &retryPeriod,
+		WebhookServer:           &k8swebhook.Server{TLSMinVersion: "1.2"},
 	})
 
 	if err != nil {


### PR DESCRIPTION
Signed-off-by: Jonathan Marcantonio <jmarcant@redhat.com>

PR enforces TLSv1.2 and confirmed using nmap script ssl-enum-ciphers:

Before enforcement:
```
| ssl-enum-ciphers: 
|   TLSv1.0: 
|     ciphers: 
|       ...
|   TLSv1.1: 
|     ciphers: 
|       ...
|   TLSv1.2: 
|     ciphers: 
|       ...
```

After enforcement:

```
| ssl-enum-ciphers: 
|   TLSv1.2: 
|     ciphers: 
|       ...
```
Addresses:
 - https://github.com/stolostron/backlog/issues/26685