### PR TITLE
Update leader election settings

### DIFF
--- a/cmd/manager/exec/manager.go
+++ b/cmd/manager/exec/manager.go
@@ -21,7 +21,6 @@ import (
 	"log"
 	"os"
 	"path/filepath"
-	"time"
 
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/client-go/tools/clientcmd"
@@ -132,9 +131,11 @@ func RunManager() {
 		logger.Info("LeaderElection disabled as not running in cluster")
 	}
 
-	leaseDuration := time.Duration(options.LeaderElectionLeaseDurationSeconds) * time.Second
-	renewDeadline := time.Duration(options.RenewDeadlineSeconds) * time.Second
-	retryPeriod := time.Duration(options.RetryPeriodSeconds) * time.Second
+	logger.Info("Leader election settings",
+		"leaseDuration", options.LeaderElectionLeaseDuration,
+		"renewDeadline", options.LeaderElectionRenewDeadline,
+		"retryPeriod", options.LeaderElectionRetryPeriod)
+
 	// Create a new Cmd to provide shared dependencies and start components
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		MetricsBindAddress:      fmt.Sprintf("%s:%d", metricsHost, metricsPort),
@@ -142,9 +143,9 @@ func RunManager() {
 		LeaderElection:          enableLeaderElection,
 		LeaderElectionID:        "multicloud-operators-channel-leader.open-cluster-management.io",
 		LeaderElectionNamespace: "kube-system",
-		LeaseDuration:           &leaseDuration,
-		RenewDeadline:           &renewDeadline,
-		RetryPeriod:             &retryPeriod,
+		LeaseDuration:           &options.LeaderElectionLeaseDuration,
+		RenewDeadline:           &options.LeaderElectionRenewDeadline,
+		RetryPeriod:             &options.LeaderElectionRetryPeriod,
 		WebhookServer:           &k8swebhook.Server{TLSMinVersion: "1.2"},
 	})
 

--- a/cmd/manager/exec/options.go
+++ b/cmd/manager/exec/options.go
@@ -14,6 +14,8 @@
 package exec
 
 import (
+	"time"
+
 	pflag "github.com/spf13/pflag"
 )
 
@@ -21,26 +23,26 @@ const defaultSyncInterval = 60 //seconds
 
 // ChannelCMDOptions for command line flag parsing
 type ChannelCMDOptions struct {
-	MetricsAddr                        string
-	KubeConfig                         string
-	SyncInterval                       int
-	LeaderElect                        bool
-	Debug                              bool
-	LogLevel                           bool
-	LeaderElectionLeaseDurationSeconds int
-	RenewDeadlineSeconds               int
-	RetryPeriodSeconds                 int
+	MetricsAddr                 string
+	KubeConfig                  string
+	SyncInterval                int
+	LeaderElect                 bool
+	Debug                       bool
+	LogLevel                    bool
+	LeaderElectionLeaseDuration time.Duration
+	LeaderElectionRenewDeadline time.Duration
+	LeaderElectionRetryPeriod   time.Duration
 }
 
 var (
 	options = ChannelCMDOptions{
-		MetricsAddr:                        "",
-		SyncInterval:                       defaultSyncInterval,
-		Debug:                              false,
-		LogLevel:                           false,
-		LeaderElectionLeaseDurationSeconds: 137,
-		RenewDeadlineSeconds:               107,
-		RetryPeriodSeconds:                 26,
+		MetricsAddr:                 "",
+		SyncInterval:                defaultSyncInterval,
+		Debug:                       false,
+		LogLevel:                    false,
+		LeaderElectionLeaseDuration: 137 * time.Second,
+		LeaderElectionRenewDeadline: 107 * time.Second,
+		LeaderElectionRetryPeriod:   26 * time.Second,
 	}
 )
 
@@ -106,24 +108,31 @@ func ProcessFlags() {
 		"zap-devel, default only log INFO(fasle), set to true for debugging",
 	)
 
-	flag.IntVar(
-		&options.LeaderElectionLeaseDurationSeconds,
+	flag.DurationVar(
+		&options.LeaderElectionLeaseDuration,
 		"leader-election-lease-duration",
-		options.LeaderElectionLeaseDurationSeconds,
-		"The leader election lease duration in seconds.",
+		options.LeaderElectionLeaseDuration,
+		"The duration that non-leader candidates will wait after observing a leadership "+
+			"renewal until attempting to acquire leadership of a led but unrenewed leader "+
+			"slot. This is effectively the maximum duration that a leader can be stopped "+
+			"before it is replaced by another candidate. This is only applicable if leader "+
+			"election is enabled.",
 	)
 
-	flag.IntVar(
-		&options.RenewDeadlineSeconds,
-		"renew-deadline",
-		options.RenewDeadlineSeconds,
-		"The renew deadline in seconds.",
+	flag.DurationVar(
+		&options.LeaderElectionRenewDeadline,
+		"leader-election-renew-deadline",
+		options.LeaderElectionRenewDeadline,
+		"The interval between attempts by the acting master to renew a leadership slot "+
+			"before it stops leading. This must be less than or equal to the lease duration. "+
+			"This is only applicable if leader election is enabled.",
 	)
 
-	flag.IntVar(
-		&options.RetryPeriodSeconds,
-		"retry-period",
-		options.RetryPeriodSeconds,
-		"The retry period in seconds.",
+	flag.DurationVar(
+		&options.LeaderElectionRetryPeriod,
+		"leader-election-retry-period",
+		options.LeaderElectionRetryPeriod,
+		"The duration the clients should wait between attempting acquisition and renewal "+
+			"of a leadership. This is only applicable if leader election is enabled.",
 	)
 }


### PR DESCRIPTION
This PR updates the leader election settings and renames the leader election options from 
``` 
--renew-deadline ==> leader-election-renew-deadline
--retry-period ==> leader-election-retry-period
```