### PR TITLE
ACM-5222 Enforce server side TLSv1.3

### DIFF
--- a/cmd/manager/exec/manager.go
+++ b/cmd/manager/exec/manager.go
@@ -146,7 +146,7 @@ func RunManager() {
 		LeaseDuration:           &options.LeaderElectionLeaseDuration,
 		RenewDeadline:           &options.LeaderElectionRenewDeadline,
 		RetryPeriod:             &options.LeaderElectionRetryPeriod,
-		WebhookServer:           &k8swebhook.Server{TLSMinVersion: "1.2"},
+		WebhookServer:           &k8swebhook.Server{TLSMinVersion: "1.3"},
 	})
 
 	if err != nil {


### PR DESCRIPTION
This PR enforces sever side TLSv1.3, confirmed using nmap script ssl-enum-ciphers:

Before enforcement:
```
| ssl-enum-ciphers: 
|   TLSv1.2: 
|     ciphers: 
|        ...
|   TLSv1.3: 
|     ciphers: 
|       ...
|_  least strength: C
```
After:
```
| ssl-enum-ciphers: 
|   TLSv1.3: 
|     ciphers: 
|      ...
|_  least strength: A
```

Pushed change directly to midstream by accident, meant to first push it here.

Addresses:
 - https://issues.redhat.com/browse/ACM-5222