### PR TITLE
change application-manager user

### DIFF
--- a/pkg/controller/channel/channel_controller.go
+++ b/pkg/controller/channel/channel_controller.go
@@ -440,7 +440,7 @@ func (r *ReconcileChannel) validateClusterRBAC(instance *chv1.Channel, logger lo
 			rbac.Subject{
 				APIGroup: "rbac.authorization.k8s.io",
 				Kind:     "User",
-				Name:     "system:open-cluster-management:cluster:" + cl.Name + ":addon:application-manager:agent:appmgr",
+				Name:     "system:open-cluster-management:cluster:" + cl.Name + ":addon:application-manager:agent:application-manager",
 			},
 			rbac.Subject{
 				APIGroup: "rbac.authorization.k8s.io",


### PR DESCRIPTION
* [X] I have taken backward compatibility into consideration.

The application-manger addon has modified its user to this convention
```
system:cluster:<cluster name>:addon:application-manager:agent:application-manager
```